### PR TITLE
Remove unnecessarily restrictive lifetime annotation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ where
     V: Clone + Serialize + for<'vde> Deserialize<'vde>,
 {
     /// Creates a new instance of the KV store
-    pub fn new(p: &'static str) -> Result<KV<K, V>, PersyError> {
+    pub fn new(p: &str) -> Result<KV<K, V>, PersyError> {
         // create and open the persy instance
         match Persy::create(p) {
             Ok(o) => o,


### PR DESCRIPTION
Hi,

I'm using typedb in a small hobby project and I like it very much.

I only had the problem, that the file path needed to be of lifetime `'static`, so (afaik) it would have been needed to already be known at compile time, whereas I want to load files dynamically during runtime. Since I could not see where this is needed, I removed it and it still works (tested with unit tests and by copying it directly into my code).